### PR TITLE
use correct group id

### DIFF
--- a/themes/minimesos/layouts/partials/gradle_snippets.html
+++ b/themes/minimesos/layouts/partials/gradle_snippets.html
@@ -13,7 +13,7 @@
 <div class="instructions-content">
     <code>
  dependencies {<br/>
- &nbsp;&nbsp;compile 'com.github.ContainerSolutions:minimesos:{{ index $latestRelease "tag_name" }}'<br/>
+ &nbsp;&nbsp;compile 'com.github.ContainerSolutions.minimesos:minimesos:{{ index $latestRelease "tag_name" }}'<br/>
  &nbsp;}
     </code>
 </div>

--- a/themes/minimesos/layouts/partials/maven_snippets.html
+++ b/themes/minimesos/layouts/partials/maven_snippets.html
@@ -12,7 +12,7 @@
 <div class="instructions-content">
     <code>
 								&lt;dependency&gt;<br/>
-&nbsp;&nbsp;&lt;groupId&gt;com.github.ContainerSolutions&lt;/groupId&gt; <br/>
+&nbsp;&nbsp;&lt;groupId&gt;com.github.ContainerSolutions.minimesos&lt;/groupId&gt; <br/>
 &nbsp;&nbsp;&lt;artifactId&gt;minimesos&lt;/artifactId&gt;<br/>
 &nbsp;&nbsp;&lt;version&gt;{{ index $latestRelease "tag_name" }}&lt;/version&gt; <br/>
 &lt;/dependency&gt;


### PR DESCRIPTION
Using this:

```
        <dependency>
            <groupId>com.github.ContainerSolutions</groupId>
            <artifactId>minimesos</artifactId>
            <version>0.13.0</version>
        </dependency>
```

results in the following error:

```
java.lang.ExceptionInInitializerError
	at org.codehaus.groovy.runtime.InvokerHelper.<clinit>(InvokerHelper.java:65)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.createCallStaticSite(CallSiteArray.java:75)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.createCallSite(CallSiteArray.java:162)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at com.containersol.minimesos.config.ConfigParser.<clinit>(ConfigParser.groovy)
	at com.containersol.minimesos.mesos.MesosClusterContainersFactory.createMesosCluster(MesosClusterContainersFactory.java:148)
	at com.containersol.minimesos.junit.MesosClusterTestRule.fromFile(MesosClusterTestRule.java:37)
	at com.github.cstroe.minimesos.MiniMesosTest.<init>(MiniMesosTest.java:13)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:217)
	at org.junit.runners.BlockJUnit4ClassRunner$1.runReflectiveCall(BlockJUnit4ClassRunner.java:266)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:263)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:51)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:237)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: groovy.lang.GroovyRuntimeException: Conflicting module versions. Module [groovy-all is loaded in version 2.4.7 and you are trying to load version 2.4.5
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl$DefaultModuleListener.onModule(MetaClassRegistryImpl.java:512)
	at org.codehaus.groovy.runtime.m12n.ExtensionModuleScanner.scanExtensionModuleFromProperties(ExtensionModuleScanner.java:80)
	at org.codehaus.groovy.runtime.m12n.ExtensionModuleScanner.scanExtensionModuleFromMetaInf(ExtensionModuleScanner.java:74)
	at org.codehaus.groovy.runtime.m12n.ExtensionModuleScanner.scanClasspathModules(ExtensionModuleScanner.java:56)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.<init>(MetaClassRegistryImpl.java:113)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.<init>(MetaClassRegistryImpl.java:74)
	at groovy.lang.GroovySystem.<clinit>(GroovySystem.java:36)
	... 36 more
```

The correct dependency is:

```
        <dependency>
            <groupId>com.github.ContainerSolutions.minimesos</groupId>
            <artifactId>minimesos</artifactId>
            <version>0.13.0</version>
        </dependency>
```

Seems like an issue caused by the Gradle release config ...